### PR TITLE
First review: ideas, suggestions, questions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -77,9 +77,11 @@ this repository and fill out the template.
     They will be asked to provide reviews as comments on your issue within 3 weeks.
 -   We ask that you respond to reviewers' comments within 2 weeks of the
     last-submitted review, but you may make updates to your compendia or respond
-    at any time.  We encourage ongoing conversations between authors and
-    reviewers. See the [reviewing guide](reviewing_guide.md) for more details.
--   Once your compendia is approved, we will provide further instructions on
+    at any time.
+    We encourage ongoing conversations between authors and reviewers.
+    If you update your compendium, please leave a short notice in your issue about the change.
+    See the [reviewing guide](reviewing_guide.md) for more details.
+-   Once your compendium is approved, we will provide further instructions on
     transferring your repository to the DataONE repository.
 
 Our [code of conduct](policies.md/#code-of-conduct) is mandatory for everyone

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,7 +70,7 @@ Thank you for considering submitting your research compendium for the DataONE re
 -   Next, [open a new issue](https://github.com/benmarwick/onboarding-reproducible-compendia/issues/new) in
 this repository and fill out the template.
 -   An [editor](#editors) will review your submission within 5 business
-    days and respond with next steps. The editor may assign the compendia to
+    days and respond with next steps (see [editors guide](editors_guide.md) for details). The editor may assign the compendia to
     reviewers, request that the compendia be updated to meet minimal criteria
     before review, or reject the compendia due to lack of fit or overlap.
 -   If your compendia meets minimal criteria, the editor will assign 1-3 reviewers.

--- a/README.Rmd
+++ b/README.Rmd
@@ -63,7 +63,7 @@ Thank you for considering submitting your research compendium for the DataONE re
 
 -   Consult our [policies](policies.md) see if your compendia meets our
     criteria for review
-    -    If you are unsure whether a compendia meets our criteria, feel free to open
+    -    If you are unsure whether a compendium meets our criteria, feel free to open
          an issue as a pre-submission inquiry to ask if the compendium is appropriate.
 -   Follow our [compendia style guide](packaging_guide.md) to ensure your compendia
   meets our style and quality criteria.
@@ -73,7 +73,7 @@ this repository and fill out the template.
     days and respond with next steps. The editor may assign the compendia to
     reviewers, request that the compendia be updated to meet minimal criteria
     before review, or reject the compendia due to lack of fit or overlap.
--   If your compendia meets minimal criteria, the editor will assign  1-3 reviewers.
+-   If your compendia meets minimal criteria, the editor will assign 1-3 reviewers.
     They will be asked to provide reviews as comments on your issue within 3 weeks.
 -   We ask that you respond to reviewers' comments within 2 weeks of the
     last-submitted review, but you may make updates to your compendia or respond
@@ -86,7 +86,7 @@ Our [code of conduct](policies.md/#code-of-conduct) is mandatory for everyone
 involved in our review process.
 
 Our review process is always in development, and we encourage feedback and discussion
-on how to improve the process on our [issue tracker](https://github.com/benmarwick/onboarding-reproducible-compendia/issues/1)
+on how to improve the process on our [issue tracker](https://github.com/benmarwick/onboarding-reproducible-compendia/issues/1).
 
 # <a href="#editors" name="editors"></a> Useful documents in this repository
 

--- a/editor_template.md
+++ b/editor_template.md
@@ -1,12 +1,12 @@
 ### Editor checks:
 
-- [ ] **Fit**: The compendium meets [criteria](policies.md)
+- [ ] **Fit**: The compendium meets [criteria](policies.md).
 - [ ] **Automated tests:** Compendium has a testing suite and is tested via Travis-CI or another CI service.
 - [ ] **Data:** The data are separate from the other components, described, ...etc...
-- [ ] **License:** The package has the recommended licenses
-- [ ] **Repository:** The repository link resolves correctly
-- [ ] **Archive**  The repository DOI resolves correctly
-- [ ] **Version** Does the release version given match the GitHub release (v1.0.0)?
+- [ ] **License:** The compendium has the recommended licenses or reasoned deviations.
+- [ ] **Repository:** The repository link resolves correctly.
+- [ ] **Archive:** The repository DOI resolves correctly.
+- [ ] **Version:** Does the release version given match the GitHub release (v1.0.0)?
 
 ---
 

--- a/editors_guide.md
+++ b/editors_guide.md
@@ -8,13 +8,13 @@ a system of a rotating Editor-in-Chief (EiC).
 The EiC serves for 3 months or a time agreed to by all members of the editorial
 board. The EiC plays the following roles
 
-- Watch all issues posted to the onboarding repo:
--  Assigns compendia to other editors, including self, to handle. Mostly this just rotates among editors, unless the EiC thinks an editor is particularly suited to a package, or an editor rejects due to being too busy/conflict of interest.
+- Watches all issues posted to the onboarding repo.
+- Assigns compendia to other editors, including self, to handle. Mostly this just rotates among editors, unless the EiC thinks an editor is particularly suited to a submission, or an editor rejects due to being too busy/conflict of interest.
 - Raises scope/overlap issue with all editors if they see an ambiguous case.  This
 may also be done by handling editors (see below). 
- - Responds to pre-submission inquiries and `meta` issues posted to the onboarding
+- Responds to pre-submission inquiries and `meta` issues posted to the onboarding
  repo, similarly pinging channel if discussion needed.  But editors should all feel free to chime in on these if they want.
- - Monitors pace of review process and reminds other editors to move packages
+- Monitors pace of review process and reminds other editors to move packages
  along as needed.
 
 # Handling Editor's Checklist

--- a/editors_guide.md
+++ b/editors_guide.md
@@ -87,4 +87,3 @@ xxx
    as appropriate.
 -   Write a short summary for a regular "new compendia round-up" blog post.
 -   Tweet, etc.
-

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -67,7 +67,7 @@ a README should not merely read, "Provides access to GooberDB," but also include
 information about GooberDB, and documentation of database structure and metadata
 can be found at *link*.
 
-* We recommend not creating `README.md` directly, but from a `README.Rmd` file (an Rmarkdown file) if you have any demonstration code. The advantage of the `.Rmd` file is you can combine text with code that can be easily updated whenever your package is updated.
+* We recommend not creating `README.md` directly, but from a `README.Rmd` file (an R Markdown file) if you have any demonstration code. The advantage of the `.Rmd` file is you can combine text with code that can be easily updated whenever your package is updated.
 
 * Extensive examples should be kept for a vignette. If you want to make the vignettes more accessible before installing the package, we suggest creating a website for your package with [`pkgdown`](https://github.com/hadley/pkgdown)
 

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -26,7 +26,7 @@ DataONE accepts compendia that meet our guidelines via a streamlined [onboarding
 * Data files are clearly separated from code and other items in the compendium
 * Small data files (totalling <100 mb) should be in a `/data` directory, and if data are produced during the analysis, the input data should be clearly distinguished from the derived data (e.g. `/data/raw_data` and `/data/derived_data`) 
 * Medium to large data files (>100 mb per file) should be deposited in a trustworthy repository, and referenced in the compendium using a persistent identifier (such as a DOI)
-* Data are documented ...somehow...
+* Data are documented in plain language in a specific section in the README file, or an independent README-data.md is extensive. The data documentation should include references to external or included standards which were applied and mention metadata files included in the compendium, if existing.
 
 ## <a href="#lic" name="lic"></a> Licensing
 

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -61,11 +61,11 @@ We recognise that your choice of licenses may be constrained by your employer, s
 where issue_id is the number of the issue in the onboarding repository. For instance, the badge for [`rtimicropem`](https://github.com/ropensci/rtimicropem) review uses the number 126 since it's the [review issue number](https://github.com/ropensci/onboarding/issues/126). The badge will first indicated "under review" and then "peer-reviewed" once your package has been onboarded, and will link to the review issue.
 
 * If your package connects to a data source or online service, or wraps other software,
-consider that your package README may be the first point of entry for users.  It should provide enough information for users to understand the nature of the data, service, or software, and provide links to other relevant data and documentation.  For instance,
-a README should not merely read, "Provides access to GooberDB," but also include,
-"..., an online repository of Goober sightings in South America.  More
+consider that your package README may be the first point of entry for users. It should provide enough information for users to understand the nature of the data, service, or software, and provide links to other relevant data and documentation. For instance,
+a README should not merely read, _"Provides access to GooberDB,"_ but also include,
+_"..., an online repository of Goober sightings in South America. More
 information about GooberDB, and documentation of database structure and metadata
-can be found at *link*.
+can be found at `link`"_.
 
 * We recommend not creating `README.md` directly, but from a `README.Rmd` file (an R Markdown file) if you have any demonstration code. The advantage of the `.Rmd` file is you can combine text with code that can be easily updated whenever your package is updated.
 

--- a/packaging_guide.md
+++ b/packaging_guide.md
@@ -30,13 +30,13 @@ DataONE accepts compendia that meet our guidelines via a streamlined [onboarding
 
 ## <a href="#lic" name="lic"></a> Licensing
 
-We follow Stodden's [Reproducible Research Standard](https://web.stanford.edu/~vcs/papers/ijclp-STODDEN-2009.pdf) (RRS) which recommends:
+We recommend to follow Stodden's [Reproducible Research Standard](https://web.stanford.edu/~vcs/papers/ijclp-STODDEN-2009.pdf) (RRS) which recommends:
 
 * CC-BY for text and figures (e.g. the narrative text of your article or report), declare this in your README
 * CC-0 for data files, declare this in your README
 * MIT for code, use `devtools::use_mit_license()` to declare this in your DESCRIPTION file
 
-We recognise that your choice of licenses may be constrained by your employer, so we will also accept licenses other than those in the RRS. For example, CC-0 is also acceptable for code. 
+We recognise that your choice of licenses may be constrained by your employer, so we will also accept reasoned usage of licenses other than those in the RRS. For example, CC-0 is also acceptable for code. 
 
 ## <a href="#rme" name="rme"></a> README
 

--- a/policies.md
+++ b/policies.md
@@ -37,18 +37,18 @@ Authors of contributed compendia essentially maintain the same ownership they ha
 
 In the unlikely scenario that a contributor of a compendium requests removal of their compendium from the suite, we will honour that request.
 
-### Quality commitment 
+### Quality commitment
 
 DataONE strives to develop and promote high quality research. To ensure that your compendium meets our criteria, we review all of our submissions as part of the onboarding process, and even after acceptance will continue to chime in with improvements and bug fixes. 
 
-Despite our best efforts to support contributed software, errors are the responsibility of individual maintainers. Buggy, unmaintained software may be removed from our suite at any time.
+Despite our best efforts to support contributed software, errors are the responsibility of individual maintainers. Buggy, unmaintained software may be removed from our suite at any time by majority vote of the DataONE onboarding team of editors.
 
 ### Maintainer responsiveness
 
 If compendia maintainers do not respond in a timely manner to requests for
  fixes from us, we will remind the maintainer a number
 of times, but after 3 months (or shorter time frame, depending on how
-critical the fix is) we will make the changes ourselves.
+critical the fix is) we may choose to make the changes ourselves or put the onboarding process on hold.
 
 We urge maintainers to make sure they are receiving GitHub notifications, as
 well as making sure emails from DataONE staff are not going to their

--- a/policies.md
+++ b/policies.md
@@ -3,8 +3,8 @@
 ### Compendium submission
 
 * For a compendium to be considered for the DataONE suite, authors must initiate a request on the [onboarding](https://github.com/benmarwick/onboarding-reproducible-compendia) repository.
-* Upon an initial assessment (see Aims and Scope below), an DataONE member will assign a reviewer or follow up with additional steps. This process usually happens within 5 business days.
-* Compendia are reviewed for quality, fit, documentation, clarity and the review process is quite similar to a manuscript review (see our [compendium guide](packaging_guide.md) and [reviewing guide](reviewing_guide.md) for more details). Unlike a manuscript review, this process will be an ongoing conversation.
+* Upon an initial assessment (see Aims and Scope below), a DataONE member will assign a reviewer or follow up with additional steps. This process usually happens within 5 business days.
+* Compendia are reviewed for quality, fit, documentation, and clarity. The review process is quite similar to a manuscript review (see our [compendium guide](packaging_guide.md) and [reviewing guide](reviewing_guide.md) for more details). Unlike a manuscript review, this process will be an ongoing conversation.
 * Once all major issues and questions, and those addressable with reasonable effort, are resolved, the editor assigned to a compendium will make a decision (accept, hold, or reject). Rejections are usually done early (before the review process begins), but in rare cases a compendium may also be rejected after review & revision.
 
 ### <a href="#fit" name="#fit"></a>Aims and Scope
@@ -27,7 +27,7 @@ make exceptions.
 
 ### Role of the DataONE leadership team
 
-Compendium authors will continue to maintain and develop their software after acceptance into DataONE. Unless explicitly added as collaborators, the DataONE team will not interfere much with day to day operations. 
+Compendium authors will continue to maintain and develop their software after acceptance into DataONE. Unless explicitly added as collaborators, the DataONE team will not interfere with day to day operations. 
 
 ### Ownership of compendium
 

--- a/policies.md
+++ b/policies.md
@@ -1,6 +1,6 @@
 ## DataONE Policies
 
-### Comendium submission
+### Compendium submission
 
 * For a compendium to be considered for the DataONE suite, authors must initiate a request on the [onboarding](https://github.com/benmarwick/onboarding-reproducible-compendia) repository.
 * Upon an initial assessment (see Aims and Scope below), an DataONE member will assign a reviewer or follow up with additional steps. This process usually happens within 5 business days.
@@ -86,7 +86,7 @@ spam box.
   attention-stealing behavior are not welcome.
 * Avoid the use of personal pronouns in code comments or
   documentation. There is no need to address persons when explaining
-  code (e.g. "When the developer")
+  code (e.g. "When the developer").
 
 _This CoC adapted from the [io.js CoC](https://github.com/iojs/io.js/blob/v1.x/CONTRIBUTING.md#code-of-conduct), adapted from [Rust's 
 CoC](https://github.com/rust-lang/rust/wiki/Note-development-policy#conduct)._

--- a/policies.md
+++ b/policies.md
@@ -77,7 +77,7 @@ spam box.
   excludes people in socially marginalized groups.
 * Private harassment is also unacceptable. No matter who you are, if
   you feel you have been or are being harassed or made uncomfortable
-  by a community member, please contact us at info@ropensci.org 
+  by a community member, please contact us at support@dataone.org 
   immediately with a capture (log, photo, email) of the harassment if possible. 
   Whether you're a regular contributor or a newcomer, we 
   care about making this community a safe place for you and we've got

--- a/review_request_template.md
+++ b/review_request_template.md
@@ -10,7 +10,7 @@ Hi, this is [EDITOR]. [FRIENDLY BANTER]. I'm writing to ask if you would be will
 
 The compendium, [PACKAGE] by [AUTHOR(S)], does [FUNCTION]. You can find it on GitHub here: [REPO LINK]. We conduct our open review process via GitHub as well, here: [ONBOARDING ISSUE]
 
-If you accept, note that we ask reviewers to complete reviews in three weeks. (We’ve found it takes a similar amount of time to review a package as an academic paper.) 
+If you accept, note that we ask reviewers to complete reviews in three weeks. (We’ve found it takes a similar amount of time to review a package as an academic paper, but it's a lot more fun because it's a conversation and more instructive since it involves data and code rather just another person's findings in a text.)
 
 Our [reviewers guide] details what we look for in a compendium review, and includes links to example reviews. Our standards are detailed in our [compendium guide], and we provide reviewer [template] for you to use. If you have questions or feedback, feel free to ask me or post to the [DataONE forum].
 


### PR DESCRIPTION
I took the liberty to make some concrete suggestions for changes, let me know what to include/remove, I'm happy to update the PR with suggestions for any of the my questions/comments/suggestions below, which are also replying to #1 (let me know if I should repost the comments there, I went for a PR with compartmentalized commits because I can potentially revert or extend stuff right away):

- I really the athmosphere set up by the "Why submit..." and "Why review"!
- Is this process only for R-based compendia? IMHO that is fine to start with, but should be clarified in the README, rather than "hidden" or implicit in the packaging guide.
- I suggest to clarify how to become a reviewer - open an issue?
- Not sure which command you used to create the md file, `knitr::knit("README.Rmd")` resulted in much more changes than expected (and the loaded packages `airtabler` and `purrr` are probably not needed?)
- Categories: What about accepting compendia related to _theses_ (which must be published in a public repo, (institutional or http://thesiscommons.org/)?
- I think the roles might need some clarification, i.e. who is the "DataONE team" how do they differ from the "DataONE leadership team", and what is the role of the "Associate editors"? If I commit something to the process, I'd be encouraged if there are proper procedures and I know who is to contact if something goes wrong (very unlikely event)

- Do you plan to run an independent badge server with a DataONE branding?

- The review process will be bound to a specific tag of a repository or a DOI, right?  I like the idea of compendia being further developed after acceptance, but the reader should know  which version the DataONE onboarding evaluated. This could be part of the footer (which must be updated to a DataONE footer, right?).

- IMHO the section "Function/variable naming & general syntax" can be skipped for a compendium, and "Documentation" and all following sections are quite focussed on an ROpenSci package at the moment. Requirements could be loosened, but the section definetely needs a rewrite to not confuse readers with ROpenSci and DataONE. The structured author metadata (i.e. with roles) could be really useful and is an argument for having a `DESCRIPTION` even if there is no R code.